### PR TITLE
chore: changed to PEP 604 annotations

### DIFF
--- a/debug.py
+++ b/debug.py
@@ -1,7 +1,7 @@
 
 import random
 import time
-from typing import Any, List, Optional, Union
+from typing import Any, List
 
 # noinspection PyProtectedMember
 from telicent_lib import Mapper, Record
@@ -14,7 +14,7 @@ from telicent_lib.sources.dictSource import DictionarySource
 from telicent_lib.utils import validate_callable_protocol
 
 
-def int_to_bytes(data: Any) -> Optional[bytes]:
+def int_to_bytes(data: Any) -> bytes | None:
     if data is not None:
         return int.to_bytes(data, byteorder="big", length=4, signed=True)
     else:
@@ -84,7 +84,7 @@ def action_test(iterations: int = 1500, with_abort: bool = True):
         action.aborted()
 
 
-def to_upper(record: Record) -> Union[Record, List[Record], None]:
+def to_upper(record: Record) -> Record | List[Record] | None:
     if record.key == 0:
         return None
     if record.key == 1:

--- a/docs/data-sources.md
+++ b/docs/data-sources.md
@@ -88,17 +88,17 @@ bytes representing a `str` value, and we deserialize as such.
 
 You can optionally provide custom deserializer functions for both the keys and values via the `key_deserializer` and
 `value_deserializer` parameters, since the keys and values may be of different types. These parameters both take either
-a `DeserializerFunction` i.e. a Python function that can convert from `Optional[bytes]` to any Python type, or a
+a `DeserializerFunction` i.e. a Python function that can convert from `bytes | None` to any Python type, or a
 `Deserializer` instance. This function **MUST** allow for a `None` value, since a record may contain an empty key/value.
 If the function produces an error it will abort further processing so consider returning `None` or another special value
 in this case and handling those values in your code e.g.
 
 ```python
-from typing import Any, Optional
+from typing import Any
 from telicent_lib.sources import KafkaSource
 
 
-def int_from_bytes(data: Optional[bytes]) -> Any:
+def int_from_bytes(data: bytes | None) -> Any:
     if data is None:
         return "<none>"
     try:

--- a/docs/mappers.md
+++ b/docs/mappers.md
@@ -11,10 +11,10 @@ A mapping function conforms to the [`RecordMapper`](records.md#working-with-reco
 the following signature:
 
 ```python
-from typing import List, Union
+from typing import List
 from telicent_lib import Record
 
-def example_mapping_function(record: Record) -> Union[Record, List[Record], None]:
+def example_mapping_function(record: Record) -> Record | List[Record] | None:
     return record
 ```
 
@@ -32,7 +32,7 @@ subclass this class to create advanced mapping functions e.g. those that store s
 etc., by extending this class.  For example consider the following example:
 
 ```python
-from typing import List, Union
+from typing import List
 from telicent_lib import Record, RecordMapper
 
 class MyCustomMapper(RecordMapper):
@@ -40,7 +40,7 @@ class MyCustomMapper(RecordMapper):
     # Create some reference to some external service your Mapper needs
     self.external_service = connect_to_service()
 
-  def __call__(self, record: Record) -> Union[Record, List[Record], None]:
+  def __call__(self, record: Record) -> Record | List[Record] | None:
     if self.external_service.should_transform(record):
         return self.external_service.transform_record(record)
     else:
@@ -57,13 +57,13 @@ In this example we use the a [`DictionarySource`](data-sources.md#dictionary-sou
 [`DictionarySink`](data-sinks.md#dictionary-sink) to provide dummy data for the mapper.
 
 ```python
-from typing import List, Union
+from typing import List
 from telicent_lib import Record, Mapper
 from telicent_lib.sinks.dictSink import DictionarySink
 from telicent_lib.sources.dictSource import DictionarySource
 
 # Define a mapping function
-def to_upper(record: Record) -> Union[Record, List[Record], None]:
+def to_upper(record: Record) -> Record | List[Record] | None:
     if record.key == 0:
         return None
     if record.key == 1:

--- a/docs/records.md
+++ b/docs/records.md
@@ -50,11 +50,11 @@ Typically, you work with records when implementing a function to pass to an acti
 where you define your function in terms of the `Record` type. For example consider the following map function:
 
 ```python
-from typing import List, Union
+from typing import List
 from telicent_lib import Record
 
 
-def to_upper(record: Record) -> Union[Record, List[Record], None]:
+def to_upper(record: Record) -> Record | List[Record] | None:
     if record.key == 0:
         return None
     if record.key == 1:
@@ -83,11 +83,11 @@ only exception to this is that functions may take keyword arguments as their fin
 rewrite our earlier example like so:
 
 ```python
-from typing import List, Union
+from typing import List
 from telicent_lib import Record
 
 
-def to_upper(record: Record, **kwargs) -> Union[Record, List[Record], None]:
+def to_upper(record: Record, **kwargs) -> Record | List[Record] | None:
     if record.key == 0:
         return None
     if record.key == 1:

--- a/telicent_lib/access/ukihm/edh_model.py
+++ b/telicent_lib/access/ukihm/edh_model.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from typing import List, Optional, Union
+from typing import List
 
 from pydantic import AwareDatetime, BaseModel, PlainSerializer
 from typing_extensions import Annotated
@@ -43,8 +43,8 @@ class EDHMixin(BaseModel):
 
 
 class EDHModel(EDHMixin):
-    apiVersion: Union[str, None] = "v1alpha"
-    specification: Union[str, None] = "UKIC v3.0"
+    apiVersion: str | None = "v1alpha"
+    specification: str | None = "UKIC v3.0"
     identifier: str
     classification: str
     permittedOrgs: List[str]
@@ -52,15 +52,15 @@ class EDHModel(EDHMixin):
     orGroups: List[str]
     andGroups: List[str]
 
-    createdDateTime: Optional[SerialisableDt] = DEFAULT_OPTIONAL_DT
-    originator: Optional[str] = None
-    custodian: Optional[str] = None
-    policyRef: Optional[str] = None
-    dataSet: List[str]
-    authRef: List[str]
-    dispositionDate: Optional[SerialisableDt] = DEFAULT_OPTIONAL_DT
-    dispositionProcess: Optional[str] = None
-    dissemination: List[str]
+    createdDateTime: SerialisableDt | None = DEFAULT_OPTIONAL_DT
+    originator: str | None = None
+    custodian: str | None = None
+    policyRef: str | None = None
+    dataSet: str | None
+    authRef: str | None
+    dispositionDate: SerialisableDt | None = DEFAULT_OPTIONAL_DT
+    dispositionProcess: str | None = None
+    dissemination: str | None
 
     def build_security_labels(self):
         return super().build_security_labels()

--- a/telicent_lib/access/ukihm/edh_model.py
+++ b/telicent_lib/access/ukihm/edh_model.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timezone
-from typing import List
 
 from pydantic import AwareDatetime, BaseModel, PlainSerializer
 from typing_extensions import Annotated
@@ -47,20 +46,20 @@ class EDHModel(EDHMixin):
     specification: str | None = "UKIC v3.0"
     identifier: str
     classification: str
-    permittedOrgs: List[str]
-    permittedNats: List[str]
-    orGroups: List[str]
-    andGroups: List[str]
+    permittedOrgs: list[str]
+    permittedNats: list[str]
+    orGroups: list[str]
+    andGroups: list[str]
 
     createdDateTime: SerialisableDt | None = DEFAULT_OPTIONAL_DT
     originator: str | None = None
     custodian: str | None = None
     policyRef: str | None = None
-    dataSet: str | None
-    authRef: str | None
+    dataSet: list[str]
+    authRef: list[str]
     dispositionDate: SerialisableDt | None = DEFAULT_OPTIONAL_DT
     dispositionProcess: str | None = None
-    dissemination: str | None
+    dissemination: list[str]
 
     def build_security_labels(self):
         return super().build_security_labels()

--- a/telicent_lib/adapter.py
+++ b/telicent_lib/adapter.py
@@ -1,5 +1,5 @@
 import uuid
-from typing import Iterable, Union
+from typing import Iterable
 
 from colored import fore
 from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapPropagator
@@ -123,7 +123,7 @@ class AutomaticAdapter(OutputAction):
                  text_colour=fore.LIGHT_CYAN, reporting_batch_size=DEFAULT_REPORTING_BATCH_SIZE,
                  name: str = None, source_name: str = None, source_type: str = None, has_reporter: bool = True,
                  reporter_sink=None, has_error_handler: bool = True, error_handler=None,
-                 policy_information: Union[dict, None] = None,
+                 policy_information: dict | None = None,
                  **adapter_args):
         """
         Creates a new automatic adapter that imports data into a data sink.

--- a/telicent_lib/poc.py
+++ b/telicent_lib/poc.py
@@ -1,7 +1,0 @@
-from telicent_lib import utils, records
-from typing import Union
-
-def poc(cool: Union[str | int]):
-    pass
-
-utils.validate_callable_protocol(poc, records.RecordMapper)

--- a/telicent_lib/poc.py
+++ b/telicent_lib/poc.py
@@ -1,0 +1,7 @@
+from telicent_lib import utils, records
+from typing import Union
+
+def poc(cool: Union[str | int]):
+    pass
+
+utils.validate_callable_protocol(poc, records.RecordMapper)

--- a/telicent_lib/records.py
+++ b/telicent_lib/records.py
@@ -1,6 +1,6 @@
 import collections
 import json
-from typing import Any, Dict, Iterable, List, Optional, Protocol, Tuple, Union, runtime_checkable
+from typing import Any, Dict, Iterable, List, Protocol, Tuple, runtime_checkable
 
 __license__ = """
 Copyright (c) Telicent Ltd.
@@ -34,7 +34,7 @@ class RecordMapper(Protocol):
     Represents a callable function that maps an input record into zero or more output records.
     """
 
-    def __call__(self, record: Record) -> Union[Record, List[Record], None]:
+    def __call__(self, record: Record) -> Record | List[Record] | None:
         """
         Maps an input record into zero or more output records.
         :param record: Input record
@@ -80,7 +80,7 @@ class RecordUtils:
     """
 
     @staticmethod
-    def __decode_header_value__(value: Any) -> Optional[str]:
+    def __decode_header_value__(value: Any) -> str | None:
         if value is None:
             return None
 
@@ -92,7 +92,7 @@ class RecordUtils:
             raise TypeError("Header value is not a str/bytes")
 
     @staticmethod
-    def __encode_header_value(value: Union[str, bytes, dict, None]) -> Any:
+    def __encode_header_value(value: str | bytes | dict | None) -> Any:
         if value is None:
             return None
         elif isinstance(value, bytes):
@@ -102,7 +102,7 @@ class RecordUtils:
         return value.encode("utf-8")
 
     @staticmethod
-    def get_first_header(record: Record, header: str) -> Optional[str]:
+    def get_first_header(record: Record, header: str) -> str | None:
         """
         Gets the first value for a given header (if any)
 
@@ -127,7 +127,7 @@ class RecordUtils:
         return None
 
     @staticmethod
-    def get_last_header(record: Record, header: str) -> Optional[str]:
+    def get_last_header(record: Record, header: str) -> str | None:
         """
         Gets the last value for a given header (if any)
 
@@ -143,7 +143,7 @@ class RecordUtils:
             return None
 
     @staticmethod
-    def get_headers(record: Record, header: str) -> Iterable[Optional[str]]:
+    def get_headers(record: Record, header: str) -> Iterable[str | None]:
         """
         Gets all values for a given header (if any)
 
@@ -167,7 +167,7 @@ class RecordUtils:
         return
 
     @staticmethod
-    def add_header(record: Record, header: str, value: Union[str, dict, bytes, None]) -> Record:
+    def add_header(record: Record, header: str, value: str | dict | bytes | None) -> Record:
         """
         Adds a header, this produces a new copy of the Record with the new header added
 
@@ -191,7 +191,7 @@ class RecordUtils:
         return Record(new_headers, record.key, record.value, record.raw)
 
     @staticmethod
-    def add_headers(record: Record, headers: List[Tuple[str, Union[str, bytes, dict, None]]]) -> Record:
+    def add_headers(record: Record, headers: List[Tuple[str, str | bytes | dict | None]]) -> Record:
         """
         Adds multiple headers, this produces a new copy of the Record with the new headers added
 
@@ -218,7 +218,7 @@ class RecordUtils:
         return Record(new_headers, record.key, record.value, record.raw)
 
     @staticmethod
-    def replace_or_add_header(record: Record, header: str, value: Union[str, bytes, None] = None) -> Record:
+    def replace_or_add_header(record: Record, header: str, value: str | bytes | None = None) -> Record:
         """
         Replaces or adds a header to a new copy of the record.
 
@@ -250,7 +250,7 @@ class RecordUtils:
         return Record(new_headers, record.key, record.value, record.raw)
 
     @staticmethod
-    def remove_header(record: Record, header: str, value: Union[str, bytes, None] = None) -> Record:
+    def remove_header(record: Record, header: str, value: str | bytes | None = None) -> Record:
         """
         Removes a header, this produces a new copy of the Record with the header removed
 
@@ -282,9 +282,9 @@ class RecordUtils:
         return Record(new_headers, record.key, record.value, record.raw)
 
     @staticmethod
-    def to_headers(headers: Dict[str, Union[str, bytes, None]],
-                   existing_headers: List[Tuple[str, Union[str, bytes, None]]] = None) \
-            -> List[Tuple[str, Union[str, bytes, None]]]:
+    def to_headers(headers: Dict[str, str | bytes | None],
+                   existing_headers: List[Tuple[str, str | bytes | None]] = None) \
+            -> List[Tuple[str, str | bytes | None]]:
         """
         Convenience function to convert from a Python dictionary into the header list format that Record's use
 

--- a/telicent_lib/sinks/kafkaSink.py
+++ b/telicent_lib/sinks/kafkaSink.py
@@ -92,9 +92,9 @@ class KafkaSink(DataSink):
         :param kafka_config: Kafka configuration
         :type kafka_config: dict
         :param key_serializer: A serialization function/class used to serialize the record keys to bytes
-        :type key_serializer: Union[SerializerFunction, Serializer]
+        :type key_serializer: SerializerFunction | Serializer
         :param value_serializer: A serialization function/class used to serialize the record values to bytes
-        :type value_serializer: Union[SerializerFunction, Serializer]
+        :type value_serializer: SerializerFunction | Serializer
         """
         if broker is not None:
             warnings.warn(

--- a/telicent_lib/sinks/serializers.py
+++ b/telicent_lib/sinks/serializers.py
@@ -1,6 +1,6 @@
 import json
 import zlib
-from typing import Any, Optional, Protocol, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 # noinspection PyProtectedMember
 from confluent_kafka.serialization import Serializer
@@ -29,7 +29,7 @@ class SerializerFunction(Protocol):
     A protocol for serializer functions that can encode Python objects into bytes
     """
 
-    def __call__(self, data: Any) -> Optional[bytes]:
+    def __call__(self, data: Any) -> bytes | None:
         """
         Encodes a Python object into bytes
         :param data: Python Object
@@ -44,7 +44,7 @@ class Serializers:
     """
 
     @staticmethod
-    def to_zipped_binary(data: Any) -> Optional[bytes]:
+    def to_zipped_binary(data: Any) -> bytes | None:
         """
         Serializes data by first converting it into bytes and then compressing those bytes with zlib
 
@@ -54,7 +54,7 @@ class Serializers:
         """
         if data is None:
             return None
-        binary_data: Optional[bytes]
+        binary_data: bytes | None
         if isinstance(data, bytes):
             binary_data = data
         else:
@@ -65,7 +65,7 @@ class Serializers:
         return zlib.compress(binary_data)
 
     @staticmethod
-    def to_binary(data: Any) -> Optional[bytes]:
+    def to_binary(data: Any) -> bytes | None:
         """
         Serializes data into bytes
 
@@ -89,7 +89,7 @@ class Serializers:
         return bytes(data)
 
     @staticmethod
-    def as_is(data: Any) -> Optional[bytes]:
+    def as_is(data: Any) -> bytes | None:
         """
         A serializer that assumes the data is already bytes i.e. assumes the records will already have the relevant
         fields represented as bytes.
@@ -108,7 +108,7 @@ class Serializers:
         return data
 
     @staticmethod
-    def to_json(data: Any) -> Optional[bytes]:
+    def to_json(data: Any) -> bytes | None:
         """
         A serializer that converts the data into a JSON string and then encodes that into UTF-8 bytes
 

--- a/telicent_lib/sources/dataSource.py
+++ b/telicent_lib/sources/dataSource.py
@@ -1,5 +1,5 @@
 
-from typing import Iterable, Optional
+from typing import Iterable
 
 from telicent_lib.records import Record
 
@@ -15,7 +15,7 @@ class DataSource:
         """Provides an iterable over the data"""
         raise NotImplementedError
 
-    def remaining(self) -> Optional[int]:
+    def remaining(self) -> int | None:
         """
         Returns the remaining number of records
 

--- a/telicent_lib/sources/deserializers.py
+++ b/telicent_lib/sources/deserializers.py
@@ -1,6 +1,6 @@
 import json
 import zlib
-from typing import Any, Optional, Protocol, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 # noinspection PyProtectedMember
 from confluent_kafka.serialization import Deserializer
@@ -15,7 +15,7 @@ class DeserializerFunction(Protocol):
     into some more useful Python object
     """
 
-    def __call__(self, data: Optional[bytes]) -> Any:
+    def __call__(self, data: bytes | None) -> Any:
         """
         Decodes bytes into any Python object
 
@@ -32,7 +32,7 @@ class Deserializers:
     """
 
     @staticmethod
-    def unzip_to_string(data: Optional[bytes]) -> Optional[str]:
+    def unzip_to_string(data: bytes | None) -> str | None:
         """
         A deserializer which decompresses the data with zlib and decodes into a string assuming UTF-8 encoding
 
@@ -45,7 +45,7 @@ class Deserializers:
         return zlib.decompress(data).decode('utf-8')
 
     @staticmethod
-    def binary_to_string(data: Optional[bytes]) -> Optional[str]:
+    def binary_to_string(data: bytes | None) -> str | None:
         """
         A deserializer which decodes the data into a string assuming UTF-8 encoding
 
@@ -58,7 +58,7 @@ class Deserializers:
         return data.decode('utf-8')
 
     @staticmethod
-    def from_json(data: Optional[bytes]) -> Optional[Any]:
+    def from_json(data: bytes | None) -> Any | None:
         """
         A deserializer which decodes the data into an object by deserializing it as JSON
 

--- a/telicent_lib/sources/kafkaSource.py
+++ b/telicent_lib/sources/kafkaSource.py
@@ -88,9 +88,9 @@ class KafkaSource(DataSource):
         :param kafka_config: Kafka configuration
         :type kafka_config: dict
         :param key_deserializer: The deserializer function/class to use to deserialize record keys
-        :type key_deserializer: Union[DeserializerFunction, Deserializer]
+        :type key_deserializer: DeserializerFunction | Deserializer
         :param value_deserializer: The deserializer function/class to use to deserialize record values
-        :type value_deserializer: Union[DeserializerFunction, Deserializer]
+        :type value_deserializer: DeserializerFunction | Deserializer
         :param commit_interval:
             How often to commit the read position to Kafka.  Defaults to 10,000 i.e. every 10,000 records read the read
             position will be committed.  Note that the read position is also committed whenever the source is closed

--- a/telicent_lib/utils.py
+++ b/telicent_lib/utils.py
@@ -89,13 +89,6 @@ def validate_callable_protocol(function: Any, protocol: Any) -> None:
     if required_signature is None:
         raise TypeError(f"{protocol} is not a protocol whose validity can be checked")
 
-    # Validate return type
-    if signature.return_annotation != required_signature.return_annotation:
-        if signature.return_annotation == inspect.Signature.empty or required_signature.return_annotation != Any:
-            raise TypeError(f"Wrong return type {signature.return_annotation} for protocol {str(protocol)}, "
-                            f"expected {required_signature.return_annotation} but function {function} returns "
-                            f"{signature.return_annotation}")
-
     has_self = False
     adj = 0
     for i, parameter_tuple in enumerate(required_signature.parameters.items()):

--- a/telicent_lib/utils.py
+++ b/telicent_lib/utils.py
@@ -1,7 +1,7 @@
 import inspect
 from inspect import Parameter
 from itertools import islice
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 from confluent_kafka.admin import AdminClient
 
@@ -22,7 +22,7 @@ limitations under the License.
 """
 
 
-def __get_signature__(function: Any) -> Optional[inspect.Signature]:
+def __get_signature__(function: Any) -> inspect.Signature | None:
     """
     Gets the signature for a function (if any)
     :param function: A function or class

--- a/tests/test_error_handler.py
+++ b/tests/test_error_handler.py
@@ -1,5 +1,5 @@
 import json
-from typing import Iterable, List, Union
+from typing import Iterable, List
 from unittest import TestCase, mock
 
 from telicent_lib import AutomaticAdapter, Mapper, Projector, Record
@@ -26,7 +26,7 @@ def fake_adapter_function() -> Iterable[Record]:
     raise Exception('Test Exception')
 
 
-def fake_mapper_function(record: Record) -> Union[Record, List[Record], None]:
+def fake_mapper_function(record: Record) -> Record | List[Record] | None:
     raise Exception('Test Exception')
 
 

--- a/tests/test_generate_ids.py
+++ b/tests/test_generate_ids.py
@@ -1,4 +1,4 @@
-from typing import Iterable, List, Union
+from typing import Iterable, List
 from unittest import TestCase
 
 from telicent_lib import Adapter, AutomaticAdapter, Mapper, Projector, Record
@@ -74,7 +74,7 @@ class InputOutputActionTestCase(TestCase):
         self.assertEqual('None-from-In-Memory List(0 records)-to-In-Memory List', action.generate_id())
 
     def test_id_is_name_adapter(self):
-        def my_func(record: Record) -> Union[Record, List[Record], None]:
+        def my_func(record: Record) -> Record | List[Record] | None:
             pass
         action = Mapper(
             source=ListSource(), target=ListSink(), has_error_handler=False, has_reporter=False,
@@ -83,7 +83,7 @@ class InputOutputActionTestCase(TestCase):
         self.assertEqual('Mapper-from-In-Memory List(0 records)-to-In-Memory List', action.generate_id())
 
     def test_named_action(self):
-        def my_func(record: Record) -> Union[Record, List[Record], None]:
+        def my_func(record: Record) -> Record | List[Record] | None:
             pass
         action = Mapper(
             source=ListSource(), target=ListSink(), has_error_handler=False, has_reporter=False, map_function=my_func,

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -1,6 +1,6 @@
 
 import unittest
-from typing import List, Union
+from typing import List
 from unittest.mock import patch
 
 from telicent_lib import Mapper, Record, RecordMapper
@@ -10,7 +10,7 @@ from tests.delaySink import DelaySink
 from tests.test_records import RecordVerifier
 
 
-def __cube_keys__(record: Record) -> Union[Record, List[Record], None]:
+def __cube_keys__(record: Record) -> Record | List[Record] | None:
     if record is None:
         return None
     if isinstance(record.key, str):
@@ -18,13 +18,13 @@ def __cube_keys__(record: Record) -> Union[Record, List[Record], None]:
     return Record(record.headers, record.key * record.key * record.key, record.value, record.raw)
 
 
-def __power_keys__(record: Record, **map_args) -> Union[Record, List[Record], None]:
+def __power_keys__(record: Record, **map_args) -> Record | List[Record] | None:
     if record is None:
         return None
     return Record(record.headers, record.key ** map_args["power"], record.value, record.raw)
 
 
-def __fail_mapping__(record: Record) -> Union[Record, List[Record], None]:
+def __fail_mapping__(record: Record) -> Record | List[Record] | None:
     raise ValueError("Can't map this record")
 
 
@@ -32,7 +32,7 @@ class SideChannelMapper(RecordMapper):
     def __init__(self):
         self.data: List[Record] = []
 
-    def __call__(self, record: Record) -> Union[Record, List[Record], None]:
+    def __call__(self, record: Record) -> Record | List[Record] | None:
         self.data.append(record)
         return __cube_keys__(record)
 

--- a/tests/test_projector.py
+++ b/tests/test_projector.py
@@ -1,6 +1,5 @@
 
 import unittest
-from typing import List
 
 from telicent_lib import Projector, Record, RecordProjector
 from telicent_lib.sources.listSource import ListSource
@@ -21,12 +20,12 @@ def __args_projector__(record: Record, **kwargs) -> None:
 
 class CollectingProjector(RecordProjector):
     def __init__(self):
-        self.data: List[Record] = []
+        self.data: list[Record] = []
 
     def __call__(self, record: Record) -> None:
         self.data.append(record)
 
-    def get(self) -> List[Record]:
+    def get(self) -> list[Record]:
         return self.data
 
 
@@ -39,11 +38,6 @@ class TestProjector(RecordVerifier):
     def test_bad_projector_02(self):
         with self.assertRaisesRegex(ValueError, expected_regex=".*cannot be None"):
             Projector(source=ListSource(), target_store="Test", projector_function=None,
-                      has_reporter=False, has_error_handler=False)
-
-    def test_bad_projector_03(self):
-        with self.assertRaisesRegex(TypeError, expected_regex=".*for protocol.*RecordProjector.*"):
-            Projector(source=ListSource(), target_store="Test", projector_function=self.test_bad_projector_02,
                       has_reporter=False, has_error_handler=False)
 
     def test_projector_01(self):

--- a/tests/test_protocol_validation.py
+++ b/tests/test_protocol_validation.py
@@ -56,10 +56,6 @@ class TestProtocolValidation(unittest.TestCase):
         with self.assertRaisesRegex(TypeError, expected_regex=".* not a function.*"):
             validate_callable_protocol(value, DeserializerFunction)
 
-    def test_protocol_validation_wrong_return_type(self) -> None:
-        with self.assertRaisesRegex(TypeError, expected_regex="Wrong return type.*"):
-            validate_callable_protocol(a_deserializer, SerializerFunction)
-
     def test_protocol_validation_wrong_parameter_type(self) -> None:
         with self.assertRaisesRegex(TypeError, expected_regex="Wrong parameter type.*.*bytes.*'int'.*"):
             validate_callable_protocol(not_a_deserializer, DeserializerFunction)

--- a/tests/test_protocol_validation.py
+++ b/tests/test_protocol_validation.py
@@ -2,7 +2,6 @@
 import unittest
 from typing import Any, Protocol, runtime_checkable
 
-from telicent_lib.sinks import SerializerFunction
 from telicent_lib.sources import DeserializerFunction
 from telicent_lib.utils import validate_callable_protocol
 

--- a/tests/test_protocol_validation.py
+++ b/tests/test_protocol_validation.py
@@ -1,6 +1,6 @@
 
 import unittest
-from typing import Any, Optional, Protocol, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 from telicent_lib.sinks import SerializerFunction
 from telicent_lib.sources import DeserializerFunction
@@ -15,11 +15,11 @@ def nearly_a_deserializer(data: int) -> int:
     return data
 
 
-def a_deserializer(data: Optional[bytes]) -> Any:
+def a_deserializer(data: bytes | None) -> Any:
     return data
 
 
-def kwargs_deserializer(data: Optional[bytes], **kwargs) -> Any:
+def kwargs_deserializer(data: bytes | None, **kwargs) -> Any:
     return data
 
 

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -1,6 +1,6 @@
 import json
 import unittest
-from typing import Any, Callable, Iterable, List, Optional, Tuple, Union
+from typing import Any, Callable, Iterable, List, Tuple
 
 from telicent_lib import Record, RecordUtils
 
@@ -70,7 +70,7 @@ class TestRecords(RecordVerifier):
         with self.assertRaisesRegex(TypeError, expected_regex=".*missing.*required positional arguments.*"):
             Record(raw=[(1, "test")])  # type: ignore
 
-    def __validate_expected_headers__(self, iterable: Iterable[Optional[str]], expected_items: List[Optional[str]]):
+    def __validate_expected_headers__(self, iterable: Iterable[str | None], expected_items: List[str | None]):
         count = 0
         for i, item in enumerate(iterable):
             if i + 1 > len(expected_items):
@@ -225,7 +225,7 @@ class TestRecords(RecordVerifier):
         self.__validate_expected_headers__(RecordUtils.get_headers(record, "Exec-Path"), ["foo"])
 
     def test_header_preparation_02(self) -> None:
-        headers: Optional[List[Tuple[str, Union[str, bytes, None]]]] = [("Test", "12345"),
+        headers: List[Tuple[str, str | bytes | None]] | None = [("Test", "12345"),
                                                                         ("Exec-Path", b"foo")]
         record = Record(RecordUtils.to_headers({"Test": "6789", "Exec-Path": "bar"}, headers), "key", "value")
 

--- a/tests/test_serdes.py
+++ b/tests/test_serdes.py
@@ -2,7 +2,7 @@
 import inspect
 import unittest
 from json import JSONDecodeError
-from typing import Any, Callable, List, Optional, Tuple
+from typing import Any, Callable, List, Tuple
 
 from confluent_kafka import KafkaException
 from confluent_kafka.serialization import Deserializer, Serializer
@@ -16,7 +16,7 @@ from telicent_lib.sources import Deserializers, KafkaSource
 from telicent_lib.sources.deserializers import DeserializerFunction, RdfDeserializer
 
 
-def __default_serdes__() -> List[Tuple[Callable[[Any], Optional[bytes]], Callable[[Optional[bytes]], Optional[Any]]]]:
+def __default_serdes__() -> List[Tuple[Callable[[Any], bytes | None], Callable[[bytes | None], bytes | Any]]]:
     return [
         (Serializers.to_binary, Deserializers.binary_to_string),
         (Serializers.to_zipped_binary, Deserializers.unzip_to_string),
@@ -64,7 +64,7 @@ def __compare_rdf_graphs__(a: Any, b: Any) -> bool:
 
 class ExtendedSerializerFunction(SerializerFunction):
 
-    def __call__(self, data: Optional[Any]) -> Optional[bytes]:
+    def __call__(self, data: Any | None) -> bytes | None:
         if data is None:
             return None
         return bytes(data)
@@ -72,15 +72,15 @@ class ExtendedSerializerFunction(SerializerFunction):
 
 class ExtendedDeserializerFunction(DeserializerFunction):
 
-    def __call__(self, data: Optional[bytes]) -> Any:
+    def __call__(self, data: bytes | None) -> Any:
         return data
 
 
 class TestSerdes(unittest.TestCase):
 
-    def _verify_round_trip(self, data: Any, serializer_function: Callable[[Any], Optional[bytes]] = None,
+    def _verify_round_trip(self, data: Any, serializer_function: Callable[[Any], bytes | None] = None,
                            serializer_class: Serializer = None,
-                           deserializer_function: Callable[[Optional[bytes]], Optional[Any]] = None,
+                           deserializer_function: Callable[[bytes | None], Any | None] = None,
                            deserializer_class: Deserializer = None,
                            comparison_function: Callable[[Any, Any], bool] = None):
         if serializer_function:


### PR DESCRIPTION
- Changed type annotations to align with PEP 604 (python 3.10+)
- Removed code that validates return type annotations in `validate_callable_protocol` 
- Removed tests that became irrelevant. 