### PR TITLE
feat: deprecated RdfSerializer and RdfDeserializer

### DIFF
--- a/telicent_lib/sinks/serializers.py
+++ b/telicent_lib/sinks/serializers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import warnings
 import zlib
 from typing import Any, Protocol, runtime_checkable
 
@@ -143,6 +144,12 @@ class RdfSerializer(Serializer):
             a Dataset.  Defaults to NTriples 1.1 since that's a subset of the NQuads format used as the default for
             `rdf_format`
         """
+        warnings.warn(
+            "`telicent_lib.sinks.serializers.RdfSerializer` has been deprecated. "
+            "You should serialize RDF data yourself before calling `send()`.",
+            DeprecationWarning,
+            stacklevel=2
+        )
         super().__init__()
         self.rdf_format = rdf_format
         self.require_context_awareness = require_context_awareness

--- a/telicent_lib/sources/deserializers.py
+++ b/telicent_lib/sources/deserializers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import warnings
 import zlib
 from typing import Any, Protocol, runtime_checkable
 
@@ -8,6 +9,22 @@ from typing import Any, Protocol, runtime_checkable
 from confluent_kafka.serialization import Deserializer
 from rdflib import Dataset
 from rdflib.graph import DATASET_DEFAULT_GRAPH_ID
+
+__license__ = """
+Copyright (c) Telicent Ltd.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
 
 
 @runtime_checkable
@@ -84,6 +101,12 @@ class RdfDeserializer(Deserializer):
         :param rdf_format:
             The default RDF format to assume when deserializing.  If not specified we're using NQuads as the default
         """
+        warnings.warn(
+            "`telicent_lib.sources.deserializer.RdfDeserializer` has been deprecated. "
+            "You should deserialize RDF data yourself.",
+            DeprecationWarning,
+            stacklevel=2
+        )
         self.rdf_format = rdf_format
 
     def __call__(self, value, ctx=None):


### PR DESCRIPTION
Both of these will be removed in the next release of telicent-lib.