### PR TITLE
feat: dead letter queue support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,7 @@ celerybeat.pid
 *.sage.py
 
 # Environments
+*.env
 .env
 .venv
 env/

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -42,6 +42,55 @@ def process_data():
 ...
 ```
 
+## Dead Letter Queues
+
+When mapping data, an invalid or failed record can be sent to a dead letter queue. If the mapper uses
+a `KafkaSink`, the dead letter queue is automatically initialised using a topic with "-dlq" appended to the 
+target topic. E.g. a mapper targetting "knowledge" would have a dead letter queue, "knowledge-dlq".
+
+When mapping an item, if an error is encountered a `DLQException` can be raised. The exception
+message should state the reason for the item going to DLQ.
+
+```python
+from telicent_lib.exceptions import DLQException
+
+
+def my_mapper(record):
+    ...
+    if not valid_function(data):
+       raise DLQException("Record did not pass validation function") 
+    ... 
+```
+
+This will create a message in the dead letter queue topic on Kafka with the initial input record as the message's
+body. Additionally, the exception message will be present in a `Dead-Letter-Reason` header and the offset of the record
+will be present in the `Dead-Letter-Offset` header.
+
+
+### Manually managing a Dead Letter Queue with a mapper
+
+It is possible to manually configure and manage a dead letter queue. This is required when using
+a mapper with a target that is not a `KafkaSink`.
+
+You must initialise your own sink and provide that to the mapper. The sink does not have to be 
+of the same class as the mapper's target sink, but it must extend the `DataSink` base class.
+
+```python
+my_dlq = MySink()
+mapper.set_dlq_target(my_dlq)
+```
+
+### Sending messages to a dead letter queue from an adapter
+
+Unlike with a mapper, an adapter has no inbound Kafka record. The inbound record will depend
+on the source being adapted. It is still possible to make use of a dead letter queue, it just 
+requires the user manages the data that is sent to it.
+
+```python
+adapter.send_dlq_record(record, dlq_reason, dlq_offset)
+```
+
+
 ## Configuration
 
 ### Environment Variables

--- a/telicent_lib/action.py
+++ b/telicent_lib/action.py
@@ -538,7 +538,13 @@ class OutputAction(Action):
 
     def send_dlq_record(self, record: Record, dlq_reason: str):
         if self.dlq_target is not None:
-            RecordUtils.add_headers(record, [('Dead-Letter-Reason', dlq_reason)])
+            RecordUtils.add_headers(
+                record,
+                [
+                    ('Exec-Path', str(self.generated_id)),
+                    ('Dead-Letter-Reason', dlq_reason)
+                ]
+            )
             self.dlq_target.send(record)
 
     def send(self, record: Record):

--- a/telicent_lib/exceptions.py
+++ b/telicent_lib/exceptions.py
@@ -31,9 +31,16 @@ class ConfigurationException(Exception):
         self.message = message
         super().__init__(self.message)
 
+
 class SourceNotFoundException(Exception):
     def __init__(self, source_name, message=None):
         self.source_name = source_name
         self.message = (message if message else f"Source {source_name} not found on the specified bootstrap" \
                          " server, are you sure this source exists?")
         super().__init__(self.message)
+
+
+class DLQException(BaseException):
+    """
+    Raised by mappers when sending a record to a dlq
+    """

--- a/telicent_lib/mapper.py
+++ b/telicent_lib/mapper.py
@@ -6,6 +6,7 @@ from opentelemetry.trace.propagation.tracecontext import TraceContextTextMapProp
 
 from telicent_lib.action import DEFAULT_REPORTING_BATCH_SIZE, InputOutputAction
 from telicent_lib.config.configurator import Configurator
+from telicent_lib.exceptions import DLQException
 from telicent_lib.records import RecordMapper, RecordUtils
 from telicent_lib.sinks import DataSink
 from telicent_lib.sources import DataSource
@@ -129,10 +130,15 @@ class Mapper(InputOutputAction):
                             # send onto the target sink.  Also, there's the potential that a record should not be mapped
                             # at all in which case None would be returned.
                             with self.tracer.start_as_current_span("map function"):
-                                if self.map_args:
-                                    output_data = self.map_function(record, **self.map_args)
-                                else:
-                                    output_data = self.map_function(record)
+                                try:
+                                    if self.map_args:
+                                        output_data = self.map_function(record, **self.map_args)
+                                    else:
+                                        output_data = self.map_function(record)
+                                except DLQException as e:
+                                    self.send_dlq_record(record, str(e))
+                                    continue
+
                             self.record_processed()
                             with self.tracer.start_as_current_span("process output"):
                                 if output_data is not None:

--- a/telicent_lib/mapper.py
+++ b/telicent_lib/mapper.py
@@ -180,7 +180,6 @@ class Mapper(InputOutputAction):
                                                     'Security-Label',
                                                     header_value
                                                 )
-                                        print('sending to target')
                                         self.target.send(output_data)
                                     self.record_output()
                 self.finished()

--- a/telicent_lib/mapper.py
+++ b/telicent_lib/mapper.py
@@ -137,6 +137,7 @@ class Mapper(InputOutputAction):
                                         output_data = self.map_function(record)
                                 except DLQException as e:
                                     self.send_dlq_record(record, str(e))
+                                    self.record_processed()
                                     continue
 
                             self.record_processed()
@@ -179,6 +180,7 @@ class Mapper(InputOutputAction):
                                                     'Security-Label',
                                                     header_value
                                                 )
+                                        print('sending to target')
                                         self.target.send(output_data)
                                     self.record_output()
                 self.finished()

--- a/telicent_lib/sinks/kafkaSink.py
+++ b/telicent_lib/sinks/kafkaSink.py
@@ -102,7 +102,7 @@ class KafkaSink(DataSink):
                 DeprecationWarning,
                 stacklevel=2
             )
-        if debug is not None:
+        if debug:
             warnings.warn(
                 "Parameter 'debug' has been deprecated. Please use a logger to view debug messages.",
                 DeprecationWarning,

--- a/tests/test_dlq.py
+++ b/tests/test_dlq.py
@@ -100,7 +100,7 @@ class MapperDLQTestCase(TestCase):
         mapper = Mapper(source=source, target=target, map_function=map_func, has_reporter=False, disable_metrics=True)
 
         self.assertIsInstance(mapper.dlq_target, KafkaSink)
-        self.assertEqual(mapper.dlq_target.topic, 'target_test-dlq')
+        self.assertEqual(mapper.dlq_target.topic, 'source_test.dlq')
 
     @mock.patch.dict(os.environ, {"BOOTSTRAP_SERVERS": "localhost:1234"})
     @mock.patch('telicent_lib.sinks.kafkaSink.Producer', MockProducer)
@@ -114,11 +114,11 @@ class MapperDLQTestCase(TestCase):
         mapper.run()
 
         # Ensure DLQ has a message
-        self.assertEqual(len(mapper.dlq_target.target.produced_messages['target_test-dlq']), 1)
+        self.assertEqual(len(mapper.dlq_target.target.produced_messages['source_test.dlq']), 1)
 
         # Ensure mapper's target topic didn't get a message
         self.assertNotIn('target_test', mapper.target.target.produced_messages)
 
         # Ensure headers are present
-        dlq_message = mapper.dlq_target.target.produced_messages['target_test-dlq'][0]
-        self.assertEqual(dlq_message[2][2], ('Dead-Letter-Reason', b'Test Exception'))
+        dlq_message = mapper.dlq_target.target.produced_messages['source_test.dlq'][0]
+        self.assertEqual(dlq_message[2][1], ('Dead-Letter-Reason', b'Test Exception'))

--- a/tests/test_dlq.py
+++ b/tests/test_dlq.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import logging
+import os
+from unittest import TestCase, mock
+
+from telicent_lib.exceptions import DLQException
+from telicent_lib.mapper import Mapper
+from telicent_lib.records import Record
+from telicent_lib.sinks.kafkaSink import KafkaSink
+from telicent_lib.sources import KafkaSource
+
+logger = logging.getLogger(__name__)
+
+
+class MockProducer(mock.MagicMock):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.produced_messages = {}
+
+    def close(self, *args, **kwargs):
+        pass
+
+    def produce(self, topic, key, value, headers):
+        if topic not in self.produced_messages:
+            self.produced_messages[topic] = [[key, value, headers]]
+        else:
+            self.produced_messages[topic].append([key, value, headers])
+
+    def flush(self, *args, **kwargs):
+        pass
+
+    def poll(self, *args, **kwargs):
+        pass
+
+
+class MockRecord(mock.MagicMock):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def error(self):
+        return None
+
+    def topic(self):
+        return 'topic'
+
+    def partition(self):
+        return 1
+
+    def headers(self):
+        return (('my-header', 'my-header-value'),)
+
+
+class MockConsumer(mock.MagicMock):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.returned_count = 0
+        self.desired_message_count = 1
+
+    def list_topics(self, *args, **kwargs):
+        pass
+
+    def subscribe(self, *args, **kwargs):
+        pass
+
+    def close(self, *args, **kwargs):
+        pass
+
+    def poll(self, *args, **kwargs):
+        if self.returned_count < self.desired_message_count:
+            self.returned_count += 1
+            return MockRecord()
+        else:
+            raise StopIteration
+
+    def commit(self, *args, **kwargs):
+        pass
+
+
+def map_func(record: Record) -> Record | list[Record] | None:
+    return record
+
+
+def map_func_with_exception(record: Record) -> Record | list[Record] | None:
+    raise DLQException('Test Exception')
+
+
+class MapperDLQTestCase(TestCase):
+
+    @mock.patch.dict(os.environ, {"BOOTSTRAP_SERVERS": "localhost:1234"})
+    @mock.patch('telicent_lib.sinks.kafkaSink.Producer', MockProducer)
+    @mock.patch('telicent_lib.utils.AdminClient', MockConsumer)
+    @mock.patch('telicent_lib.sources.kafkaSource.Consumer', MockConsumer)
+    def test_kafka_mapper_automatically_gets_dlq(self):
+        source = KafkaSource('source_test')
+        target = KafkaSink('target_test')
+        mapper = Mapper(source=source, target=target, map_function=map_func, has_reporter=False, disable_metrics=True)
+
+        self.assertIsInstance(mapper.dlq_target, KafkaSink)
+        self.assertEqual(mapper.dlq_target.topic, 'target_test-dlq')
+
+    @mock.patch.dict(os.environ, {"BOOTSTRAP_SERVERS": "localhost:1234"})
+    @mock.patch('telicent_lib.sinks.kafkaSink.Producer', MockProducer)
+    @mock.patch('telicent_lib.utils.AdminClient', MockConsumer)
+    @mock.patch('telicent_lib.sources.kafkaSource.Consumer', MockConsumer)
+    def test_raising_dlq_exception_sends_dlq_message(self):
+        source = KafkaSource('source_test')
+        target = KafkaSink('target_test')
+        mapper = Mapper(source=source, target=target, map_function=map_func_with_exception, has_reporter=False,
+                        disable_metrics=True)
+        mapper.run()
+
+        # Ensure DLQ has a message
+        self.assertEqual(len(mapper.dlq_target.target.produced_messages['target_test-dlq']), 1)
+
+        # Ensure mapper's target topic didn't get a message
+        self.assertNotIn('target_test', mapper.target.target.produced_messages)
+
+        # Ensure headers are present
+        dlq_message = mapper.dlq_target.target.produced_messages['target_test-dlq'][0]
+        self.assertEqual(dlq_message[2][2], ('Dead-Letter-Reason', b'Test Exception'))


### PR DESCRIPTION
Allows a dead letter queue exception to be thrown, sending the incoming record to a DQL.